### PR TITLE
移行後と移行前の記事URL対応リストをCSVで出力する

### DIFF
--- a/rails/lib/tasks/gen_post_id_set_csv.rake
+++ b/rails/lib/tasks/gen_post_id_set_csv.rake
@@ -1,3 +1,5 @@
+require 'csv'
+
 namespace :gen_post_id_set_csv do
   desc 'generate csv'
   failures = []

--- a/rails/lib/tasks/gen_post_id_set_csv.rake
+++ b/rails/lib/tasks/gen_post_id_set_csv.rake
@@ -1,0 +1,15 @@
+namespace :gen_post_id_set_csv do
+  desc 'generate csv'
+  failures = []
+  task :execute => :environment do
+    p 'start'
+
+    CSV.open("id_set.csv", "w", headers: ['kibela記事URL','Docbase記事URL','(短縮ver)Docbase記事URL'], write_headers: true) do |csv|
+      Post.where.not(kibela_url: nil).find_each do |post|
+        csv << [post.kibela_url, post.origin_url, post.origin_url.split('/').last]
+      end
+    end
+
+    p 'completed'
+  end
+end


### PR DESCRIPTION
## 概要
タイトルの通り
https://starx-inc.slack.com/archives/C01T8U4HQ2E/p1665986283630269

## 参考
https://docs.ruby-lang.org/en/3.1/CSV.html#top