### PR TITLE
kibelaへコメント移行する

### DIFF
--- a/.dockerdev/rails-psql/Dockerfile
+++ b/.dockerdev/rails-psql/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrad
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends curl gnupg2 &&\
   # ソースリストにPostgreSQLを追加
   curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - &&\
-  echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list &&\
+  echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list &&\
   # ソースリストにNodeJSを追加
   curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash - &&\
   # ソースリストにYarnを追加

--- a/rails/app/jobs/upload_comment_to_kibela_job.rb
+++ b/rails/app/jobs/upload_comment_to_kibela_job.rb
@@ -1,0 +1,15 @@
+class UploadCommentToKibelaJob
+  include Sidekiq::Worker
+  sidekiq_options queue: :default, retry: 3
+
+  def perform(post_id)
+    comment = Comment.find(post_id)
+    comment.upload_to_kibela!
+  rescue Kibela::ApiError => api_error
+    if api_error.only_rate_limit?
+      UploadCommentToKibelaJob.perform_in(1800.second)
+    else
+      pp api_error
+    end
+  end
+end

--- a/rails/app/jobs/upload_comment_to_kibela_job.rb
+++ b/rails/app/jobs/upload_comment_to_kibela_job.rb
@@ -1,6 +1,6 @@
 class UploadCommentToKibelaJob
   include Sidekiq::Worker
-  sidekiq_options queue: :default, retry: 3
+  sidekiq_options queue: :default, retry: false
 
   def perform(post_id)
     comment = Comment.find(post_id)

--- a/rails/app/models/comment.rb
+++ b/rails/app/models/comment.rb
@@ -26,4 +26,17 @@ class Comment < ApplicationRecord
     }
     self
   end
+
+  def upload_to_kibela!
+    adapter = Kibela::Adapter.new
+    commentable_id = post.kibela_id
+    content = body
+    # 退会済ユーザーはdummy_userとする
+    author_id = user&.kibela_id || 'VXNlci82NjE'
+    response = adapter.create_comment(title, commentable_id, content, author_id)
+    self.kibela_id = response.data.create_comment.comment.id
+    self.kibela_url = response.data.create_comment.comment.path
+    self.kibela_updated_at = Time.now
+    self.save!
+  end
 end

--- a/rails/app/models/comment.rb
+++ b/rails/app/models/comment.rb
@@ -33,7 +33,7 @@ class Comment < ApplicationRecord
     content = body
     # 退会済ユーザーはdummy_userとする
     author_id = user&.kibela_id || 'VXNlci82NjE'
-    response = adapter.create_comment(title, commentable_id, content, author_id)
+    response = adapter.create_comment(commentable_id, content, author_id)
     self.kibela_id = response.data.create_comment.comment.id
     self.kibela_url = response.data.create_comment.comment.path
     self.kibela_updated_at = Time.now

--- a/rails/app/models/comment.rb
+++ b/rails/app/models/comment.rb
@@ -9,6 +9,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  kibela_id         :string
+#  kibela_url        :string
 #  kibela_updated_at :datetime
 #
 class Comment < ApplicationRecord

--- a/rails/app/models/concerns/kibela/adapter.rb
+++ b/rails/app/models/concerns/kibela/adapter.rb
@@ -4,6 +4,7 @@ class Kibela::Adapter
   include Kibela::Queries::Groups
 
   include Kibela::Mutations::CreateNote
+  include Kibela::Mutations::CreateComment
   include Kibela::Mutations::CreateDummyUser
   include Kibela::Mutations::CreateAttachment
 

--- a/rails/app/models/concerns/kibela/mutations/create_comment.rb
+++ b/rails/app/models/concerns/kibela/mutations/create_comment.rb
@@ -12,7 +12,7 @@ module Kibela::Mutations::CreateComment
     }
   GRAPHQL
   
-  def create_comment(title, commentable_id, content, author_id)
+  def create_comment(commentable_id, content, author_id)
     query(
       Mutation,
       variables: {

--- a/rails/app/models/concerns/kibela/mutations/create_comment.rb
+++ b/rails/app/models/concerns/kibela/mutations/create_comment.rb
@@ -2,10 +2,10 @@ module Kibela::Mutations::CreateComment
   extend ActiveSupport::Concern
   
   Mutation = Kibela::Client::Client.parse <<-'GRAPHQL'
-    mutation createComment($input: CreateCommentInput!) {
+    mutation ($input: CreateCommentInput!) {
       createComment(input: $input) {
         comment {
-          id
+          id,
           path
         }
       }

--- a/rails/app/models/concerns/kibela/mutations/create_comment.rb
+++ b/rails/app/models/concerns/kibela/mutations/create_comment.rb
@@ -1,0 +1,27 @@
+module Kibela::Mutations::CreateComment
+  extend ActiveSupport::Concern
+  
+  Mutation = Kibela::Client::Client.parse <<-'GRAPHQL'
+    mutation createComment($input: CreateCommentInput!) {
+      createComment(input: $input) {
+        comment {
+          id
+          path
+        }
+      }
+    }
+  GRAPHQL
+  
+  def create_comment(title, commentable_id, content, author_id)
+    query(
+      Mutation,
+      variables: {
+        input: {
+          commentableId: commentable_id,
+          content: content,
+          authorId: author_id
+        }
+      }
+    )
+  end
+end

--- a/rails/app/services/upload_comments_to_kibela_service.rb
+++ b/rails/app/services/upload_comments_to_kibela_service.rb
@@ -1,0 +1,7 @@
+class UploadCommentsToKibelaService
+  def execute
+    Comment.find_each do |comment|
+      UploadCommentToKibelaJob.perform_in(1.second, comment.id)
+    end
+  end
+end

--- a/rails/db/migrate/20230115094414_add_kibela_url_to_comments.rb
+++ b/rails/db/migrate/20230115094414_add_kibela_url_to_comments.rb
@@ -1,0 +1,5 @@
+class AddKibelaUrlToComments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comments, :kibela_url, :string
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_04_064239) do
+ActiveRecord::Schema.define(version: 2023_01_15_094414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2022_09_04_064239) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "kibela_id"
     t.datetime "kibela_updated_at"
+    t.string "kibela_url"
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end


### PR DESCRIPTION
## 概要
タイトルの通り

## やること
- [x] コメント移行
  - [x] kibela_id / kibela_url / kibela_updated_at へ各種情報を保存

⚠️ 退会済ユーザーのコメントはdummy_userのコメントとする

## やらないこと
- [x] コメントの入れ子対応（Docbaseで対応していないのでもはやできない）

## 補足
### kibelaのコメント作成APIについて
#### mutation
```graphql
mutation createComment($input: CreateCommentInput!) {
  createComment(input: $input) {
    comment {
      id
      path
    }
  }
}
```

#### variables
`commentableId` はnoteのID

```json
{
  "input": {
    "commentableId": "xxxxx",
    "content": "xxxx",
    "authorId": "xxxx"
  }
}
```

